### PR TITLE
Fixed typo in Flow name

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<summary>Notification action for Nextcloud Flow</summary>
 	<description><![CDATA[Enable users to configure notifications with customized conditions in their Flow configuration.
 
-Users are empowered to configure a "Sent a notification" Flow in their personal settings. They can choose between the events being triggered, and other conditions like filetypes, assigned tags, time ranges and more. They can specify an inscription so that when the notification appears they will have context.
+Users are empowered to configure a "Send a notification" Flow in their personal settings. They can choose between the events being triggered, and other conditions like filetypes, assigned tags, time ranges and more. They can specify an inscription so that when the notification appears they will have context.
 
 ![Notification Flow Configuration](https://raw.githubusercontent.com/nextcloud/flow_notifications/master/screenshots/configuration.png)
 

--- a/lib/Flow/Operation.php
+++ b/lib/Flow/Operation.php
@@ -73,7 +73,7 @@ class Operation implements IOperation {
 	 * @inheritDoc
 	 */
 	public function getDisplayName(): string {
-		return $this->l->t('Sent a notification');
+		return $this->l->t('Send a notification');
 	}
 
 	/**


### PR DESCRIPTION
I think the flow should actually be called "Send a notification" instead of "Sent a notification" right?

This change requires to change the translations accordingly and update the screenshots.

Signed-off-by: DrRSatzteil <thomas_lauterbach@arcor.de>