### PR TITLE
Handle url gracefull

### DIFF
--- a/lib/Flow/Operation.php
+++ b/lib/Flow/Operation.php
@@ -145,7 +145,10 @@ class Operation implements IOperation {
 					->setDateTime(new DateTime());
 
 				if ($entity instanceof IUrl) {
-					$notification->setLink($entity->getUrl());
+					$url = $entity->getUrl();
+					if ($url === '') {
+						$notification->setLink($url);
+					}
 				}
 
 				$this->notificationManager->notify($notification);


### PR DESCRIPTION
If an entirity implements the IUrl interface it is not guaranteed it
returns something properly. For example an empty string is fine in some
case (if there is no url). This flow should not crash on that.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>