### PR TITLE
[stable29] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -729,12 +729,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "5d14cd5c2d92046ce268033a8e420f4acf054403"
+                "reference": "55e817ce1b36e2fb92839d5368f38d2ea97ee536"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5d14cd5c2d92046ce268033a8e420f4acf054403",
-                "reference": "5d14cd5c2d92046ce268033a8e420f4acf054403",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/55e817ce1b36e2fb92839d5368f38d2ea97ee536",
+                "reference": "55e817ce1b36e2fb92839d5368f38d2ea97ee536",
                 "shasum": ""
             },
             "require": {
@@ -765,7 +765,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable29"
             },
-            "time": "2025-01-08T00:43:58+00:00"
+            "time": "2025-01-27T08:38:56+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency