### PR TITLE
[stable34] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -1,16 +1,17 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
-d4697182231bf364a34d8dd8b9e52a00 appstore-build-publish.yml
+3c9e67bdc06a172cae6461ab6801f95e appstore-build-publish.yml
 2581a67c5bcdcd570427e6d51db767d7 fixup.yml
 2a205b6cc57c26c31a18a7f41190f3e2 lint-eslint.yml
 023b664746d1f2e09a9aaaac772ff7f5 lint-info-xml.yml
-870b483dbcbca59479211270d61546dd lint-php-cs.yml
+660a12f14e32c1b2d24c418232d918da lint-php-cs.yml
 ee2b04d185b82fe7dd6fe6d83c6c7b45 lint-php.yml
 351799835db66dd8d20e324970490e96 lint-stylelint.yml
 03759c9dc0fa748cb927b9f9cadf2925 node.yml
 7e9fa275fffbfef58e6348a44750e2ec npm-audit-fix.yml
-3c4a096b3b7dbaef0f8e5190ffe13518 pr-feedback.yml
-20b5d0d45766e3793f19c9c0c8d05140 psalm.yml
+d1821b8a816578070ed8fd018f321f6d pr-feedback.yml
+87bff1e6b8ae3ec6522b134a3d0f7a1c psalm.yml
 3975dc58817119d596a8f6ed190352ce reuse.yml
 a3440826636c0fd7c2d20b1de50363da update-nextcloud-ocp-approve-merge.yml
-39db87018db395caf41007931817cdbd update-nextcloud-ocp.yml
+661b96e2d459555a19b99f5f68c334ce update-nextcloud-ocp.yml
+fcdb95d98ab64de64587191bbd71b2cb npm-build.yml

--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -103,9 +103,11 @@ jobs:
 
       - name: Install composer dependencies
         if: steps.check_composer.outputs.files_exists == 'true'
-        run: |
-          cd ${{ env.APP_NAME }}
-          composer install --no-dev
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+        with:
+          composer-options: '--no-dev'
+          working-directory: ${{ env.APP_NAME }}
+          ignore-cache: 'yes'
 
       - name: Build ${{ env.APP_NAME }}
         # Skip if no package.json

--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -43,10 +43,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
+      - name: Remove nextcloud/ocp
         run: |
           composer remove nextcloud/ocp --dev --no-scripts
-          composer i
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       - name: Lint
         run: composer run cs:check || ( echo 'Please run `composer run cs:fix` to format your code' && exit 1 )

--- a/.github/workflows/pr-feedback.yml
+++ b/.github/workflows/pr-feedback.yml
@@ -36,7 +36,7 @@ jobs:
           blocklist=$(curl https://raw.githubusercontent.com/nextcloud/.github/master/non-community-usernames.txt | paste -s -d, -)
           echo "blocklist=$blocklist" >> "$GITHUB_OUTPUT"
 
-      - uses: nextcloud/pr-feedback-action@f0cab224dea8e1f282f9451de322f323c78fc7a5 # main
+      - uses: nextcloud/pr-feedback-action@5227c55be184087d0aef6338bee210d8620b6297 # v1.0.1
         with:
           feedback-message: |
             Hello there,

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -47,12 +47,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
+      - name: Remove nextcloud/ocp
         run: |
           composer remove nextcloud/ocp --dev --no-scripts
-          composer i
 
-      - name: Install nextcloud/ocp
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+
+      - name: Install nextcloud/ocp:dev-${{ steps.versions.outputs.branches-max }}
         run: composer require --dev nextcloud/ocp:dev-${{ steps.versions.outputs.branches-max }} --ignore-platform-reqs --with-dependencies
 
       - name: Run coding standards check

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -62,9 +62,9 @@ jobs:
           grep '/appinfo/info.xml' .github/CODEOWNERS | cut -f 2- -d ' ' | xargs | awk '{ print "codeowners="$0 }' >> $GITHUB_OUTPUT
         continue-on-error: true
 
-      - name: Composer install
+      - name: Install composer dependencies
         if: steps.checkout.outcome == 'success'
-        run: composer install
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       - name: Check composer bin for nextcloud/ocp exists
         id: check_composer_bin


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [appstore-build-publish.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/appstore-build-publish.yml)
- 🆙 Updated [lint-php-cs.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-php-cs.yml)
- 🆙 Updated [npm-build.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/npm-build.yml)
- 🆙 Updated [pr-feedback.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/pr-feedback.yml)
- 🆙 Updated [psalm.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/psalm.yml)
- 🆙 Updated [update-nextcloud-ocp.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/update-nextcloud-ocp.yml)