### PR TITLE
[stable34] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -1,17 +1,17 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
-fe1239ed98a163abbdea3e0490c85458 appstore-build-publish.yml
+ed8f08fe0c056080f6afef29f15b2d49 appstore-build-publish.yml
 2581a67c5bcdcd570427e6d51db767d7 fixup.yml
-985f3ac7d51405c1601c742832a14120 lint-eslint.yml
+dc0ae733f35c60274937c2647c027d46 lint-eslint.yml
 43fd0c5fb704cabc5f11cdfaf513236d lint-info-xml.yml
-4b40dd0073e16f74dd04e6d49dcc043d lint-php-cs.yml
-cfb31e47b6e9ab65e76c89b028754a4e lint-php.yml
+79006ab196f5664fc444e63645cfd8a7 lint-php-cs.yml
+300be6a756abda800e40850918f2d964 lint-php.yml
 ab3a506506b1d7c1cea9593ecfd84366 lint-stylelint.yml
 03759c9dc0fa748cb927b9f9cadf2925 node.yml
-aff9f466debc652013b43d1a11b32a0b npm-audit-fix.yml
-d1821b8a816578070ed8fd018f321f6d pr-feedback.yml
-6dc046dfbca5dc65d938265c518fcac4 psalm.yml
+0dc931ec237a235370e224282608b20e npm-audit-fix.yml
+aaa395a26591445ccf4c8196d7f01ee7 pr-feedback.yml
+4f1080b33778a956a08efc7a41a11994 psalm.yml
 2dbec18233063b42f4d8e03bbb43671c reuse.yml
 a3440826636c0fd7c2d20b1de50363da update-nextcloud-ocp-approve-merge.yml
-f5632e6d28c6afca9d4d46131fb48d57 update-nextcloud-ocp.yml
-28dcf55e283b85c292fea0d0b2a15a8a npm-build.yml
+1919e2ff468e875aeeae5fd088d4ce1f update-nextcloud-ocp.yml
+ab958fa2b07234fceab6b6d836fb7f19 npm-build.yml

--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Get php version
         id: php-versions
-        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
         with:
           filename: ${{ env.APP_NAME }}/appinfo/info.xml
 
@@ -194,7 +194,7 @@ jobs:
           overwrite: true
 
       - name: Upload app to Nextcloud appstore
-        uses: nextcloud-releases/nextcloud-appstore-push-action@a011fe619bcf6e77ddebc96f9908e1af4071b9c1 # v1.0.3
+        uses: nextcloud-libraries/nextcloud-appstore-push-action@a011fe619bcf6e77ddebc96f9908e1af4071b9c1 # v1.0.3
         with:
           app_name: ${{ env.APP_NAME }}
           appstore_token: ${{ secrets.APPSTORE_TOKEN }}

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -28,7 +28,7 @@ jobs:
       src: ${{ steps.changes.outputs.src}}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Get php version
         id: versions
-        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
 
       - name: Set up php${{ steps.versions.outputs.php-min }}
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Get version matrix
         id: versions
-        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
 
   php-lint:
     runs-on: ubuntu-latest-low

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         branches:
           - ${{ github.event.repository.default_branch }}
+          - 'stable35'
           - 'stable34'
           - 'stable33'
           - 'stable32'

--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -28,7 +28,7 @@ jobs:
       src: ${{ steps.changes.outputs.src}}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/pr-feedback.yml
+++ b/.github/workflows/pr-feedback.yml
@@ -36,7 +36,7 @@ jobs:
           blocklist=$(curl https://raw.githubusercontent.com/nextcloud/.github/master/non-community-usernames.txt | paste -s -d, -)
           echo "blocklist=$blocklist" >> "$GITHUB_OUTPUT"
 
-      - uses: nextcloud/pr-feedback-action@5227c55be184087d0aef6338bee210d8620b6297 # v1.0.1
+      - uses: nextcloud-libraries/pr-feedback-action@5227c55be184087d0aef6338bee210d8620b6297 # v1.0.1
         with:
           feedback-message: |
             Hello there,

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get php version
         id: versions
-        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
 
       - name: Check enforcement of minimum PHP version ${{ steps.versions.outputs.php-min }} in psalm.xml
         run: grep 'phpVersion="${{ steps.versions.outputs.php-min }}' psalm.xml

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         branches:
           - ${{ github.event.repository.default_branch }}
+          - 'stable35'
           - 'stable34'
           - 'stable33'
           - 'stable32'


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [appstore-build-publish.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/appstore-build-publish.yml)
- 🆙 Updated [lint-eslint.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-eslint.yml)
- 🆙 Updated [lint-php-cs.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-php-cs.yml)
- 🆙 Updated [lint-php.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-php.yml)
- 🆙 Updated [npm-audit-fix.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/npm-audit-fix.yml)
- 🆙 Updated [npm-build.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/npm-build.yml)
- 🆙 Updated [pr-feedback.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/pr-feedback.yml)
- 🆙 Updated [psalm.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/psalm.yml)
- 🆙 Updated [update-nextcloud-ocp.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/update-nextcloud-ocp.yml)